### PR TITLE
Changed listContainer to stop listing all files w/ prefix by default

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -230,7 +230,7 @@ public class SwiftAPIClient implements IStoreClient {
     LOG.debug("List container: path parent: {}, name {}", path.getParent(), path.getName());
     Container cObj = mAccount.getContainer(container);
     String obj = path.toString().substring(hostName.length());
-    if (obj.contains("/")) {
+    if (cObj.getObject(obj.concat("/_SUCCESS")).exists()) {
       obj = obj + "/";
     }
     LOG.debug("Search: {}", obj);


### PR DESCRIPTION
Currently, the driver retrieves all files from the object store that matches with the prefix given by default. This is an issue because if you have a file named "File1" and "File10" and you want to read from "File1" only, the driver will read in both "File1" and "File10." This patch fixes this issue and returns only "File1".