### PR TITLE
Modified SwiftAPIClient.listContainer to handle wildcards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,28 @@
+
+
+ 
+Developer's Certificate of Origin 1.1
+
+       By making a contribution to this project, I certify that:
+
+       (a) The contribution was created in whole or in part by me and I
+           have the right to submit it under the Apache License 2.0; or
+
+       (b) The contribution is based upon previous work that, to the best
+           of my knowledge, is covered under an appropriate open source
+           license and I have the right under that license to submit that
+           work with modifications, whether created in whole or in part
+           by me, under the same open source license (unless I am
+           permitted to submit under a different license), as indicated
+           in the file; or
+
+       (c) The contribution was provided directly to me by some other
+           person who certified (a), (b) or (c) and I have not modified
+           it.
+
+       (d) I understand and agree that this project and the contribution
+           are public and that a record of the contribution (including all
+           personal information I submit with it, including my sign-off) is
+           maintained indefinitely and may be redistributed consistent with
+           this project or the open source license(s) involved.
+

--- a/README.md
+++ b/README.md
@@ -253,7 +253,9 @@ To easy the debug process, Please modify `conf/log4j.properties` and add
 
 	log4j.logger.com.ibm.stocator=DEBUG
 
+## Before you sumit your pull request
+We ask that you include a line similar to the following as part of your pull request comments: “DCO 1.1 Signed-off-by: Random J Developer“. “DCO” stands for “Developer Certificate of Origin,” and refers to the same text used in the Linux Kernel community. By adding this simple comment, you tell the community that you wrote the code you are contributing, or you have the right to pass on the code that you are contributing.
+
 ## Next steps
 * Code tested with Hadoop 2.6.0.
 * Token expiration was not tested (re-authentication)
-* Amazon S3 support. It seems to be very easy to add support for S3. Just copy "swift" package into "s3" and use jet3st instead of Joss. One particular issue is that Amazon S3 requires content-length for object uploads. Hence each object creation should create local tmp file, calculate it's size and only then upload to S3.

--- a/src/main/java/com/ibm/stocator/fs/ObjectStoreFileSystem.java
+++ b/src/main/java/com/ibm/stocator/fs/ObjectStoreFileSystem.java
@@ -69,7 +69,6 @@ public class ObjectStoreFileSystem extends FileSystem {
   @Override
   public void initialize(URI fsuri, Configuration conf) throws IOException {
     super.initialize(fsuri, conf);
-    LOG.debug("Initialize: {}", fsuri.toString());
     if (!conf.getBoolean("mapreduce.fileoutputcommitter.marksuccessfuljobs", true)) {
       throw new IOException("mapreduce.fileoutputcommitter.marksuccessfuljobs should be enabled");
     }
@@ -78,7 +77,6 @@ public class ObjectStoreFileSystem extends FileSystem {
     if (storageClient == null) {
       storageClient = ObjectStoreVisitor.getStoreClient(nameSpace, fsuri, conf);
       hostNameScheme = storageClient.getScheme() + "://"  + Utils.getHost(fsuri) + "/";
-      LOG.debug("ObjectStoreFileSystem has been initialized");
     }
   }
 
@@ -92,7 +90,7 @@ public class ObjectStoreFileSystem extends FileSystem {
    */
   @Override
   protected void checkPath(Path path) {
-    LOG.debug("Check path: {}", path.toString());
+    LOG.trace("Check path: {}", path.toString());
   }
 
   /**
@@ -149,7 +147,6 @@ public class ObjectStoreFileSystem extends FileSystem {
     if (f.getName().equals(Constants.HADOOP_SUCCESS)) {
       String objectName = storageClient.getDataRoot() + "/"
           + getObjectName(f.toString(), Constants.HADOOP_SUCCESS);
-      LOG.debug("Going to create {}", objectName);
       FSDataOutputStream outStream = storageClient.createObject(objectName,
           "application/directory", statistics);
       outStream.close();
@@ -159,7 +156,6 @@ public class ObjectStoreFileSystem extends FileSystem {
       objNameModified = storageClient.getDataRoot() + "/"
           + getObjectName(f.toString(), Constants.HADOOP_TEMPORARY)
           + "/" + f.getName();
-      LOG.debug("Transformed to: {}", objNameModified);
     }
     FSDataOutputStream outStream = storageClient.createObject(objNameModified,
         "binary/octet-stream", statistics);
@@ -285,7 +281,6 @@ public class ObjectStoreFileSystem extends FileSystem {
    * @return new object name
    */
   private String getObjectName(String path, String boundary) {
-    LOG.trace("Extract object name from: {} with boundary {}", path, boundary);
     String noPrefix = path.substring(hostNameScheme.length());
     int pIdx = path.indexOf(boundary);
     String objectName = "";
@@ -305,7 +300,6 @@ public class ObjectStoreFileSystem extends FileSystem {
         //path matches pattern in javadoc
         objectName = noPrefix.substring(0, npIdx - 1);
       }
-      LOG.debug("getObjectName - objectName: {}", objectName);
       return objectName;
     }
     return noPrefix;

--- a/src/main/java/com/ibm/stocator/fs/swift/ConfigurationHandler.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/ConfigurationHandler.java
@@ -64,13 +64,11 @@ public final class ConfigurationHandler {
    * @throws IOException if the configuration is invalid
    */
   public static Properties initialize(URI uri, Configuration conf) throws IOException {
-    LOG.debug("Swift driver: initialize start");
     String host = Utils.getHost(uri);
     String container = Utils.getContainerName(host);
     String service = Utils.getServiceName(host);
     LOG.debug("container: {}, service: {}", container , service);
     String prefix = SWIFT_SERVICE_PREFIX + service;
-    LOG.debug("Filesystem {}, using conf keys {}", uri, prefix);
     Properties props = new Properties();
     props.setProperty(SWIFT_CONTAINER_PROPERTY, container);
     Utils.updateProperty(conf, prefix, AUTH_URL, props, SWIFT_AUTH_PROPERTY, true);
@@ -89,7 +87,6 @@ public final class ConfigurationHandler {
     } else {
       Utils.updateProperty(conf, prefix,  REGION, props, SWIFT_REGION_PROPERTY, false);
     }
-    LOG.debug("Initialize completed successfully");
     return props;
   }
 

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -34,14 +34,9 @@ import org.javaswift.joss.client.factory.AuthenticationMethod;
 import org.javaswift.joss.model.Access;
 import org.javaswift.joss.model.Account;
 import org.javaswift.joss.model.Container;
-<<<<<<< HEAD
 import org.javaswift.joss.model.DirectoryOrObject;
 import org.javaswift.joss.model.StoredObject;
-=======
-//import org.javaswift.joss.model.PaginationMap;
-import org.javaswift.joss.model.StoredObject;
-import org.javaswift.joss.model.DirectoryOrObject;
->>>>>>> f7de8acf047d9ea26674282d760df8d631298c93
+
 import org.javaswift.joss.model.Directory;
 
 import org.slf4j.Logger;

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -34,8 +34,14 @@ import org.javaswift.joss.client.factory.AuthenticationMethod;
 import org.javaswift.joss.model.Access;
 import org.javaswift.joss.model.Account;
 import org.javaswift.joss.model.Container;
+<<<<<<< HEAD
 import org.javaswift.joss.model.DirectoryOrObject;
 import org.javaswift.joss.model.StoredObject;
+=======
+//import org.javaswift.joss.model.PaginationMap;
+import org.javaswift.joss.model.StoredObject;
+import org.javaswift.joss.model.DirectoryOrObject;
+>>>>>>> f7de8acf047d9ea26674282d760df8d631298c93
 import org.javaswift.joss.model.Directory;
 
 import org.slf4j.Logger;
@@ -303,6 +309,7 @@ public class SwiftAPIClient implements IStoreClient {
           tmpResult.add(fs);
           LOG.debug("{} added to results", e.getName());
         }
+
       }
 
     }

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -288,16 +288,21 @@ public class SwiftAPIClient implements IStoreClient {
         fs = new FileStatus(e.getAsObject().getContentLength(), false, 1, blockSize,
                 getLastModified(e.getAsObject().getLastModified()), 0, null, null, null,
                 new Path(newMergedPath));
-        LOG.debug("{} is a object", newMergedPath);
+        LOG.debug("{} is an object", newMergedPath);
+        if (fs.getLen() > 0) {
+          tmpResult.add(fs);
+          LOG.debug("{} added to results", e.getName());
+        }
       } else {
-        fs = new FileStatus(0, true, 1, blockSize,
-                0, 0, null, null, null,
-                new Path(newMergedPath));
-        LOG.debug("{} is a directory", newMergedPath);
-      }
-      if (fs.getLen() > 0 || fs.isDirectory()) {
-        tmpResult.add(fs);
-        LOG.debug("{} added to results", e.getName());
+        StoredObject success = cObj.getObject(e.getName() + Constants.HADOOP_SUCCESS);
+        if (success.exists()) {
+          fs = new FileStatus(0, true, 1, blockSize,
+                  0, 0, null, null, null,
+                  new Path(newMergedPath));
+          LOG.debug("{} is a directory", newMergedPath);
+          tmpResult.add(fs);
+          LOG.debug("{} added to results", e.getName());
+        }
       }
 
     }

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -277,8 +277,8 @@ public class SwiftAPIClient implements IStoreClient {
       elements = cObj.listDirectory();
       LOG.debug("Listing root directory");
     } else {
-      Directory dir = new Directory(path.toString()
-              .substring(hostName.length()) + Path.SEPARATOR, Path.SEPARATOR_CHAR);
+      Directory dir = new Directory(path.toString().substring(hostName.length())
+                                    + Path.SEPARATOR, Path.SEPARATOR_CHAR);
       elements = cObj.listDirectory(dir);
       LOG.debug("Directory {} listed", dir.getName());
     }
@@ -287,8 +287,8 @@ public class SwiftAPIClient implements IStoreClient {
       String newMergedPath = getMergedPath(hostName, path, e.getName());
       if (e.isObject()) {
         fs = new FileStatus(e.getAsObject().getContentLength(), false, 1, blockSize,
-                getLastModified(e.getAsObject().getLastModified()), 0, null, null, null,
-                new Path(newMergedPath));
+                            getLastModified(e.getAsObject().getLastModified()), 0, null, null, null,
+                            new Path(newMergedPath));
         LOG.debug("{} is an object", newMergedPath);
         if (fs.getLen() > 0) {
           tmpResult.add(fs);
@@ -298,15 +298,13 @@ public class SwiftAPIClient implements IStoreClient {
         StoredObject success = cObj.getObject(e.getName() + Constants.HADOOP_SUCCESS);
         if (success.exists()) {
           fs = new FileStatus(0, true, 1, blockSize,
-                  0, 0, null, null, null,
-                  new Path(newMergedPath));
+                              0, 0, null, null, null,
+                              new Path(newMergedPath));
           LOG.debug("{} is a directory", newMergedPath);
           tmpResult.add(fs);
           LOG.debug("{} added to results", e.getName());
         }
-
       }
-
     }
     return tmpResult.toArray(new FileStatus[tmpResult.size()]);
   }

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -35,8 +35,8 @@ import org.javaswift.joss.model.Access;
 import org.javaswift.joss.model.Account;
 import org.javaswift.joss.model.Container;
 import org.javaswift.joss.model.DirectoryOrObject;
-import org.javaswift.joss.model.PaginationMap;
 import org.javaswift.joss.model.StoredObject;
+import org.javaswift.joss.model.Directory;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -268,48 +268,39 @@ public class SwiftAPIClient implements IStoreClient {
   public FileStatus[] listContainer(String hostName, Path path) throws IOException {
     LOG.debug("List container: path parent: {}, name {}", path.getParent(), path.getName());
     Container cObj = mAccount.getContainer(container);
-    String obj = path.toString().substring(hostName.length());
-    if (obj.contains("/")) {
-      obj = obj + "/";
+    ArrayList<FileStatus> tmpResult = new ArrayList<>();
+    FileStatus fs;
+    Collection<DirectoryOrObject> elements;
+
+    if (path.getParent() == null) {
+      elements = cObj.listDirectory();
+      LOG.debug("Listing root directory");
+    } else {
+      Directory dir = new Directory(path.toString()
+              .substring(hostName.length()) + Path.SEPARATOR, Path.SEPARATOR_CHAR);
+      elements = cObj.listDirectory(dir);
+      LOG.debug("Directory {} listed", dir.getName());
     }
-    LOG.debug("Search: {}", obj);
-    ArrayList<FileStatus> tmpResult = new ArrayList<FileStatus>();
-    PaginationMap paginationMap = cObj.getPaginationMap(obj, 100);
-    FileStatus fs = null;
-    for (Integer page = 0; page < paginationMap.getNumberOfPages(); page++) {
-      LOG.debug("Going to list page {}", page);
-      Collection<StoredObject> res = cObj.list(paginationMap, page);
-      if (page == 0 && (res == null || res.isEmpty())) {
-        FileStatus[] emptyRes = {};
-        return emptyRes;
+
+    for (DirectoryOrObject e: elements) {
+      String newMergedPath = getMergedPath(hostName, path, e.getName());
+      if (e.isObject()) {
+        fs = new FileStatus(e.getAsObject().getContentLength(), false, 1, blockSize,
+                getLastModified(e.getAsObject().getLastModified()), 0, null, null, null,
+                new Path(newMergedPath));
+        LOG.debug("{} is a object", newMergedPath);
+      } else {
+        fs = new FileStatus(0, true, 1, blockSize,
+                0, 0, null, null, null,
+                new Path(newMergedPath));
+        LOG.debug("{} is a directory", newMergedPath);
       }
-      for (StoredObject tmp : res) {
-        fs = null;
-        String newMergedPath = getMergedPath(hostName, path, tmp.getName());
-        LOG.debug("inside listing loop: new name {}, old name {} size {}", newMergedPath,
-            tmp.getName(), tmp.getContentLength());
-        if (tmp.getContentLength() == 0) {
-          // we may hit a well knownn Swift bug.
-          // container listing reports 0 for large objects.
-          LOG.debug("Content length is 0. Peform HEAD {}", newMergedPath);
-          StoredObject soDirect = cObj
-              .getObject(tmp.getName());
-          if (soDirect.getContentLength() > 0) {
-            fs = new FileStatus(soDirect.getContentLength(), false, 1, blockSize,
-                getLastModified(soDirect.getLastModified()), 0, null,
-                null, null, new Path(newMergedPath));
-          }
-        } else if (tmp.getContentLength() > 0) {
-          fs = new FileStatus(tmp.getContentLength(), false, 1, blockSize,
-              getLastModified(tmp.getLastModified()), 0, null,
-              null, null, new Path(newMergedPath));
-        }
-        if (fs != null && fs.getLen() > 0) {
-          tmpResult.add(fs);
-        }
+      if (fs.getLen() > 0 || fs.isDirectory()) {
+        tmpResult.add(fs);
+        LOG.debug("{} added to results", e.getName());
       }
+
     }
-    LOG.debug("Going to return list of size: {}", tmpResult.size());
     return tmpResult.toArray(new FileStatus[tmpResult.size()]);
   }
 
@@ -322,7 +313,6 @@ public class SwiftAPIClient implements IStoreClient {
       if (objectName.startsWith(p.getName())) {
         return p.getParent() + objectName;
       }
-      return p.toString();
     }
     return hostName + objectName;
   }

--- a/src/test/java/com/ibm/stocator/fs/swift2d/TestSwiftOperations.java
+++ b/src/test/java/com/ibm/stocator/fs/swift2d/TestSwiftOperations.java
@@ -77,6 +77,7 @@ public class TestSwiftOperations extends SwiftBaseTest {
     }
   }
 
+  @Test
   public void testSimilarNames() throws Exception {
     String prefix = "/aa";
     String[] names = {prefix, prefix + "12", prefix + "13"};


### PR DESCRIPTION
Currently, an exception is thrown when you try to use a path with a wildcard such as "File*", this PR fixes this and another problem. The current implementation of listContainer will list extra files. For example, if you query for "File1" you will also get "File11" if it exists in the container. This PR fixes this so that it will only return "File1" as expected.

I'm still working on a few edge cases but feel free to review and comment.