### PR TITLE
handle invalid prefix matches when listing containers

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -413,6 +413,12 @@ public class SwiftAPIClient implements IStoreClient {
           continue;
         }
         String unifiedObjectName = extractUnifiedObjectName(tmp.getName());
+        if (!unifiedObjectName.equals(obj)) {
+          // JOSS returns all objects that start with the prefix of obj.
+          // These may include other unrelated objects.
+          LOG.trace("{} does not match {}. Skipped", unifiedObjectName, obj);
+          continue;
+        }
         if (isSparkOrigin(unifiedObjectName) && !fullListing) {
           LOG.trace("{} created by Spark", unifiedObjectName);
           if (!isJobSuccessful(unifiedObjectName)) {


### PR DESCRIPTION
When saving data to an objectstore from spark, the data is saved as prefixObject/, prefixObject/part1, prefixObject/part2, ..., prefixObject/partn, prefixObject/_SUCCESS.  When reading the data back, stocator has to search the object store for all objects that have the prefix of the data (prefixObject in the case above).  The current code implementation does not check for matches against other data that happen to start with the same prefix.  As a result, when reading data in the json format, all objects that start with the same prefix are read and the resulting schema of the data returned is a union of all the different schemas.  

For example, if we have objects in the object store named: prefix, prefix-a, and prefix-b, when issuing a read request for 'prefix', the data that is returned contains a schema that is union of the schema of prefix, prefix-a, and prefix-b. 

The fix that I am proposing here is to check the result set from the list containers issued via JOSS and eliminate any objects whose prefix name does not match the object we are looking for.  

I tested this change as follows:

Test #1: I run the following python code with stocator before and after the proposed change:
from pyspark import SparkContext
from pyspark.sql import SQLContext
from pyspark.sql.types import *
import sys

sc = SparkContext()
sqlContext = SQLContext(sc)

schema1 = StructType([StructField('column1', IntegerType(), False),
                     StructField('column2', StringType(), False)])
schema2 = StructType([StructField('column3', IntegerType(), False),
                     StructField('column4', StringType(), False)])
schema3 = StructType([StructField('column5', IntegerType(), False),
                     StructField('column6', StringType(), False)])

myList = [[1,'a'],[2,'b']]
parallelList = sc.parallelize(myList).collect()
df = sqlContext.createDataFrame(parallelList, schema1)
dfTarget = df.coalesce(1)
dfTarget.write.json("swift2d://vault1.spark/testingPrefix")

myList2 = [[3,'c'],[4,'d']]
parallelList2 = sc.parallelize(myList).collect()
df2 = sqlContext.createDataFrame(parallelList, schema2)
dfTarget2 = df2.coalesce(1)
dfTarget2.write.json("swift2d://vault1.spark/testingPrefixab")

myList3 = [[5,'e'],[6,'f']]
parallelList3 = sc.parallelize(myList).collect()
df3 = sqlContext.createDataFrame(parallelList, schema3)
dfTarget3 = df3.coalesce(1)
dfTarget3.write.json("swift2d://vault1.spark/testingPrefixabc")

dfRead = sqlContext.read.json("swift2d://vault1.spark/testingPrefix")
dfRead.show()

Test #2: I manually uploaded three files to the object store.  
File 1 named prefix has this text:  
{"column1":"1","column2":"1"}
{"column1":"2","column2":"2"}
File 2 named prefix-b has this text:
{"column3":"1","column4":"1"}
{"column3":"2","column4":"2"}
File 3 named prefix-c has this text:
{"column5":"1","column6":"1"}
{"column5":"2","column6":"2"}
I then issued this command from a spark-shell: 
val df = sqlContext.read.json("swift2d://vault1.spark/prefix")

Results without the proposed change:
scala> df.printSchema
root
 |-- column1: string (nullable = true)
 |-- column2: string (nullable = true)
 |-- column3: string (nullable = true)
 |-- column4: string (nullable = true)
 |-- column5: string (nullable = true)
 |-- column6: string (nullable = true)

With the proposed change:
scala> df.printSchema
root
 |-- column1: string (nullable = true)
 |-- column2: string (nullable = true)



Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.


