### PR TITLE
single authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <findbugs.path>build/findbugs</findbugs.path>
         <slf4j.version>1.7.2</slf4j.version>
         <java.version>1.7</java.version>
-        <joss.version>0.9.12</joss.version>
+        <joss.version>0.9.13</joss.version>
         <hadoop.version>2.6.0</hadoop.version>
         <junit.version>4.12</junit.version>
         <jackson.version>1.9.7</jackson.version>

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -233,14 +233,6 @@ public class SwiftAPIClient implements IStoreClient {
             + " Verify the validitiy of the auth url: " + config.getAuthUrl());
       }
     }
-    try {
-      mJossAccount.authenticate();
-    } catch (Exception e) {
-      throw new IOException("Failed to authenticate."
-          + " Please check the provided access credentials."
-          + " Verify the validitiy of the auth url: " + config.getAuthUrl()
-          + " : " + e.getMessage());
-    }
     Container containerObj = mJossAccount.getAccount().getContainer(container);
     if (!containerObj.exists() && !authMethod.equals(PUBLIC_ACCESS)) {
       containerObj.create();

--- a/src/main/java/com/ibm/stocator/fs/swift/auth/JossAccount.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/auth/JossAccount.java
@@ -69,6 +69,10 @@ public class JossAccount {
    */
   public void createAccount() {
     mAccount = new AccountFactory(mAccountConfig).setHttpClient(httpclient).createAccount();
+    mAccess = mAccount.getAccess();
+    if (mRegion != null) {
+      mAccess.setPreferredRegion(mRegion);
+    }
   }
 
   /**
@@ -83,11 +87,13 @@ public class JossAccount {
    */
   public void authenticate() {
     if (mAccount == null) {
+      // Create account also performs authentication.
       createAccount();
-    }
-    mAccess = mAccount.authenticate();
-    if (mRegion != null) {
-      mAccess.setPreferredRegion(mRegion);
+    } else {
+      mAccess = mAccount.authenticate();
+      if (mRegion != null) {
+        mAccess.setPreferredRegion(mRegion);
+      }
     }
   }
 


### PR DESCRIPTION
The current code call authenticate() after creating a connection via JOSS.  But JOSS already performs an authentication as part of creating the connection.  This change ensures that we don't perform double authentication when not needed.  
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

Effi Ofer
