### PR TITLE
Make API work on non-US jvm locale

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/common/Utils.java
+++ b/src/main/java/com/ibm/stocator/fs/common/Utils.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 import java.util.Properties;
 
 import org.apache.hadoop.conf.Configuration;
@@ -282,7 +283,7 @@ public class Utils {
    * @throws IOException if failed to parse time stamp
    */
   public static long lastModifiedAsLong(String strTime) throws IOException {
-    final SimpleDateFormat simpleDateFormat = new SimpleDateFormat(TIME_PATTERN);
+    final SimpleDateFormat simpleDateFormat = new SimpleDateFormat(TIME_PATTERN, Locale.US);
     try {
       long lastModified = simpleDateFormat.parse(strTime).getTime();
       if (lastModified == 0) {

--- a/src/test/java/com/ibm/stocator/fs/swift2d/unittests/SwiftAPIClientTest.java
+++ b/src/test/java/com/ibm/stocator/fs/swift2d/unittests/SwiftAPIClientTest.java
@@ -19,6 +19,8 @@ package com.ibm.stocator.fs.swift2d.unittests;
 
 import org.javaswift.joss.model.StoredObject;
 import java.util.HashMap;
+import java.util.Locale;
+
 import org.javaswift.joss.client.mock.ContainerMock;
 import org.javaswift.joss.client.mock.StoredObjectMock;
 import org.javaswift.joss.client.mock.AccountMock;
@@ -164,9 +166,21 @@ public class SwiftAPIClientTest {
     String stringTime = "Fri, 06 May 2016 03:44:47 GMT";
     long longTime = 1462506287000L;
 
+    // test to see if getLastModified parses date with default locale
     long result = lastModifiedAsLong(stringTime);
     Assert.assertEquals("getLastModified() shows incorrect time",
             longTime, result);
+
+    // test to see if getLastModified parses date when default locale is different than US
+    Locale originalLocale = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.ITALIAN);
+      result = lastModifiedAsLong(stringTime);
+      Assert.assertEquals("getLastModified() shows incorrect time",
+              longTime, result);
+    } finally {
+      Locale.setDefault(originalLocale);
+    }
   }
 
   @Test


### PR DESCRIPTION
I got errors trying to run stocator on jvm with PL locales. This fix ensures that SimpleDateFormat will be able to parse last modified date on JVM running with any locale.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

