### PR TITLE
add user agent prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,12 +169,13 @@ Example, configure `<service>` as `myCOS`:
 | fs.cos.connection.establish.timeout| 50000 | amount of time (in ms) until we give up trying to establish a connection to the object store |
 | fs.cos.client.execution.timeout| 500000 | amount of time (in ms) to allow a client to complete the execution of an API call |
 | fs.cos.client.request.timeout| 500000 | amount of time to wait (in ms) for a request to complete before giving up and timing out |
-|fs.cos.connection.ssl.enabled |true | Enables or disables SSL connections to COS.|
-|fs.cos.proxy.host| | Hostname of the (optional) proxy server for COS connections. |
-|fs.cos.proxy.port| |Proxy server port. If this property is not set but fs.cos.proxy.host is, port 80 or 443 is assumed (consistent with the value of fs.cos.connection.ssl.enabled).|
+|fs.cos.connection.ssl.enabled |true | Enables or disables SSL connections to COS |
+|fs.cos.proxy.host| | Hostname of the (optional) proxy server for COS connections |
+|fs.cos.proxy.port| |Proxy server port. If this property is not set but fs.cos.proxy.host is, port 80 or 443 is assumed (consistent with the value of fs.cos.connection.ssl.enabled) |
 | fs.cos.proxy.username| |Username for authenticating with proxy server |
-| fs.cos.proxy.password| |Password for authenticating with proxy server.|
-| fs.cos.proxy.domain| |Domain for authenticating with proxy server. |
+| fs.cos.proxy.password| |Password for authenticating with proxy server |
+| fs.cos.proxy.domain| |Domain for authenticating with proxy server |
+| fs.cos.user.agent.prefix| |User agent prefix |
 
 ## Stocator and Object Storage based on OpenStack Swift API
 

--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -125,6 +125,8 @@ import static com.ibm.stocator.fs.cos.COSConstants.SOCKET_RECV_BUFFER;
 import static com.ibm.stocator.fs.cos.COSConstants.SOCKET_SEND_BUFFER;
 import static com.ibm.stocator.fs.cos.COSConstants.SOCKET_TIMEOUT;
 import static com.ibm.stocator.fs.common.Constants.HADOOP_ATTEMPT;
+import static com.ibm.stocator.fs.cos.COSConstants.USER_AGENT_PREFIX;
+import static com.ibm.stocator.fs.cos.COSConstants.DEFAULT_USER_AGENT_PREFIX;
 
 public class COSAPIClient implements IStoreClient {
 
@@ -896,7 +898,12 @@ public class COSAPIClient implements IStoreClient {
       clientConf.setSignerOverride(signerOverride);
     }
 
+    String userAgentPrefix = Utils.getTrimmed(conf, FS_COS, FS_ALT_KEYS,
+        USER_AGENT_PREFIX, DEFAULT_USER_AGENT_PREFIX);
     String userAgentName = singletoneInitTimeData.getUserAgentName();
+    if (!userAgentPrefix.equals(DEFAULT_USER_AGENT_PREFIX)) {
+      userAgentName = userAgentPrefix + " " + userAgentName;
+    }
     clientConf.setUserAgentPrefix(userAgentName);
   }
 

--- a/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java
@@ -146,4 +146,7 @@ public class COSConstants {
   public static final String PROXY_DOMAIN = ".proxy.domain";
   public static final String PROXY_WORKSTATION = ".proxy.workstation";
 
+  // User agent prefix
+  public static final String USER_AGENT_PREFIX = ".user.agent.prefix";
+  public static final String DEFAULT_USER_AGENT_PREFIX = "";
 }


### PR DESCRIPTION
Added the user agent prefix config param for COS.  With the parameter not being set we end up with the following user agent:  "user_agent":"stocator 1.0.11-SNAPSHOT, aws-sdk-java/1.11.59 Linux/3.13.0-83-generic IBM_J9_VM/2.8/1.8.0"  With the param set to "Bridge:" we end up with the following user agent: "user_agent":"Bridge: stocator 1.0.11-SNAPSHOT, aws-sdk-java/1.11.53 Linux/3.13.0-83-generic OpenJDK_64-Bit_Server_VM/25.111-b14/1.8.0_111".
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

