### PR TITLE
LocalDirAllocator workaround

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
@@ -155,7 +155,7 @@ class COSBlockOutputStream extends OutputStream {
             + COSConstants.MAX_MULTIPART_COUNT
             + " write may fail.");
       }
-      activeBlock = blockFactory.create(blockCount, blockSize);
+      activeBlock = blockFactory.create(key, blockCount, blockSize);
     }
     return activeBlock;
   }

--- a/src/main/java/com/ibm/stocator/fs/cos/COSDataBlocks.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSDataBlocks.java
@@ -158,16 +158,18 @@ final class COSDataBlocks {
     /**
      * Create a temp file and a {@link DiskBlock} instance to manage it.
      *
+     * @param key = a string containing the partition number, task number,
+     *              attempt number, and timestamp
      * @param index block index
      * @param limit limit of the block
      * @return the new block
      * @throws IOException IO problems
      */
     @Override
-    DataBlock create(long index, int limit) throws IOException {
+    DataBlock create(String key, long index, int limit) throws IOException {
+      String tmpPrefix = key.replaceAll("/", "-");
       File destFile = getOwner()
-          .createTmpFileForWrite(String.format("cosblock-%04d-", index),
-              limit);
+          .createTmpFileForWrite(String.format("cosblock-%04d-" + tmpPrefix, index));
       return new DiskBlock(destFile, limit, index);
     }
   }
@@ -339,7 +341,7 @@ final class COSDataBlocks {
      * @param statistics stats to work with
      * @return a new block
      */
-    abstract DataBlock create(long index, int limit)
+    abstract DataBlock create(String key, long index, int limit)
         throws IOException;
 
   }

--- a/src/main/java/com/ibm/stocator/fs/cos/COSLocalDirAllocator.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSLocalDirAllocator.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  (C) Copyright IBM Corp. 2015, 2016
+ */
+
+package com.ibm.stocator.fs.cos;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.util.UUID;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.LocalDirAllocator;
+import org.apache.hadoop.fs.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Extend LocalDirAllocator (An implementation of a round-robin scheme for
+ * disk allocation for creating file) to avoid callign File.createTempFile().
+ * We have found that createTempFile() results in slower runs on some machines
+ * for reasons that are not clear to us.  Possibly this has to do with the
+ * need to ensure that a file with the same name does not already exists.
+ * We have replaced createTempFile() with code that generates a unique file
+ * name using the object name, partition number, task number, attempt number,
+ * time stamp, and finally a uuid number.
+ */
+public class COSLocalDirAllocator extends LocalDirAllocator {
+  private static final Logger LOG = LoggerFactory.getLogger(COSAPIClient.class);
+  private Configuration conf;
+  public static final int SIZE_UNKNOWN = -1;
+
+  public COSLocalDirAllocator(Configuration pConf, String bufferDir) {
+    super(bufferDir);
+    conf = pConf;
+  }
+
+  private synchronized File createTmpDirForWrite(String tmpDirName) throws IOException {
+    LOG.trace("tmpDirName is {}", tmpDirName);
+    File tmpDir = new File(tmpDirName);
+    if (!tmpDir.exists()) {
+      tmpDir.mkdir();
+    }
+    return tmpDir;
+  }
+
+  public File createTmpFileForWrite(String pathStr, long size,
+      Configuration conf) throws IOException {
+    Path path = getLocalPathForWrite(pathStr, size, conf, true);
+    File tmpDir = new File(path.getParent().toUri().getPath());
+    File tmpFile = new File(tmpDir, pathStr + UUID.randomUUID().toString());
+    return tmpFile;
+  }
+}


### PR DESCRIPTION
Here's the createTmpFile() from LocalDirAllocator workaround.  This will end up creating tmp files that look as follow:

/tmp/hadoop-root/output-vault1-terasort_in_50g_testing_128mb-part-r-00262-attempt_201711161612_0001_r_000262_092ccb5ef-6ea5-410e-a0e6-281711d1d6bd

Temp files from multi part upload will look as follow:
/tmp/hadoop-root/cosblock-0006-terasort_in_50g_testing_128mb-part-r-00382-attempt_201711161619_0001_r_000382_081ade45ea-1bc1-110e-b5f2-289022e8d6ea

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

