### PR TITLE
fix: container name may contain dots in the name

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/common/Utils.java
+++ b/src/main/java/com/ibm/stocator/fs/common/Utils.java
@@ -82,7 +82,7 @@ public class Utils {
    */
   public static String getContainerName(String hostname,
       boolean serviceRequired) throws IOException {
-    int i = hostname.indexOf(".");
+    int i = hostname.lastIndexOf(".");
     if (i <= 0) {
       if (serviceRequired) {
         throw badHostName(hostname);
@@ -100,7 +100,7 @@ public class Utils {
    * @throws IOException if the hostname was invalid
    */
   public static String getServiceName(String hostname) throws IOException {
-    int i = hostname.indexOf(".");
+    int i = hostname.lastIndexOf(".");
     if (i <= 0) {
       throw badHostName(hostname);
     }

--- a/src/main/java/com/ibm/stocator/fs/common/Utils.java
+++ b/src/main/java/com/ibm/stocator/fs/common/Utils.java
@@ -113,6 +113,8 @@ public class Utils {
 
   /**
    * Extracts service name from the container.service
+   * taking care of the fact that a container may have dots
+   * in his name.
    *
    * @param hostname hostname
    * @param defaultService default value
@@ -120,7 +122,7 @@ public class Utils {
    * @throws IOException if the hostname was invalid
    */
   public static String getServiceName(String hostname, String defaultService) throws IOException {
-    int i = hostname.indexOf(".");
+    int i = hostname.lastIndexOf(".");
     if (i <= 0) {
       throw badHostName(hostname);
     }

--- a/src/test/java/com/ibm/stocator/fs/commom/unittests/CommonUtilsTest.java
+++ b/src/test/java/com/ibm/stocator/fs/commom/unittests/CommonUtilsTest.java
@@ -18,7 +18,8 @@ public class CommonUtilsTest {
       "cos://abc.service/a/b",
       "cos://abc.service",
       "cos://abc.service/",
-      "cos://bucket"};
+      "cos://bucket",
+      "cos://a.b.c.service"};
 
   private static final String[] HOST_LIST_INVALID = {"cos://abc.service/a/b",
       "cos://ab.service",
@@ -51,14 +52,20 @@ public class CommonUtilsTest {
       String container = Utils.getContainerName(host);
       exception.expect(InvalidContainerNameException.class);
       Utils.validContainer(container);
+
       host = Utils.getHost(new URI(HOST_LIST_INVALID[1]));
       container = Utils.getContainerName(host);
       exception.expect(InvalidContainerNameException.class);
       Utils.validContainer(container);
+
       host = Utils.getHost(new URI(HOST_LIST_INVALID[2]));
       container = Utils.getContainerName(host);
       exception.expect(InvalidContainerNameException.class);
       Utils.validContainer(container);
+
+      host = Utils.getHost(new URI(HOST_LIST_VALID[4]));
+      container = Utils.getContainerName(host);
+      Assert.assertEquals(container, "a.b.c");
     } catch (IOException e) {
       Assert.fail();
     } catch (URISyntaxException e) {


### PR DESCRIPTION
What: seems Stocator might incorrectly split container name and service name when the container name contains . (which is valid according to the spec)
 