### PR TITLE
set readahead default to 64KB

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -587,7 +587,8 @@ public class COSAPIClient implements IStoreClient {
   @Override
   public FSDataInputStream getObject(String hostName, Path path) throws IOException {
     String key = pathToKey(hostName, path);
-    COSInputStream inputStream = new COSInputStream(mBucket, key, mBlockSize, mClient);
+    COSInputStream inputStream = new COSInputStream(mBucket, key,
+        Constants.DEFAULT_READAHEAD_RANGE, mClient);
     return new FSDataInputStream(inputStream);
   }
 

--- a/src/main/java/com/ibm/stocator/fs/cos/COSInputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSInputStream.java
@@ -136,6 +136,8 @@ public class COSInputStream extends FSInputStream implements CanSetReadahead {
     }
     contentRangeStart = targetPos;
     contentRangeFinish = targetPos + Math.max(readahead, length) + threasholdRead;
+    LOG.trace("targetPos={} readahead={} length={} threasholdRead={} contentRangeFinish={}",
+        targetPos, readahead, length, threasholdRead, contentRangeFinish);
     if (negativeSeek < 0) {
       contentRangeFinish = targetPos + Math.abs(negativeSeek);
       negativeSeek = 0;


### PR DESCRIPTION
We are currently setting the readahead buffer to block size (128MB by default) rather than the 64KB that it should be.  This results in range reads being performed over a much larger range than needed.  
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

