### PR TITLE
Update and align dependencies with Spark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,16 +59,16 @@
     <properties>
         <checkstyle.path>build/checkstyle/</checkstyle.path>
         <findbugs.path>build/findbugs</findbugs.path>
-        <slf4j.version>1.7.10</slf4j.version>
+        <slf4j.version>1.7.16</slf4j.version>
         <java.version>1.7</java.version>
         <joss.version>0.9.15</joss.version>
         <hadoop.version>2.7.3</hadoop.version>
         <junit.version>4.12</junit.version>
-        <jackson.version>1.9.7</jackson.version>
+        <jackson.version>1.9.13</jackson.version>
         <httpcomponents.httpcore.version>4.4.8</httpcomponents.httpcore.version>
         <httpcomponents.httpclient.version>4.5.4</httpcomponents.httpclient.version>
-        <powermock.version>1.6.1</powermock.version>
-        <mockito.version>1.10.8</mockito.version>
+        <powermock.version>1.6.2</powermock.version>
+        <mockito.version>1.10.19</mockito.version>
         <amazon.sdk.version>1.11.59</amazon.sdk.version>
         <google.guava.version>23.5-jre</google.guava.version>
     </properties>
@@ -116,7 +116,7 @@
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
           <version>${google.guava.version}</version>
-        </dependency>        
+        </dependency>
         <dependency>
 	        <groupId>com.googlecode.json-simple</groupId>
 	        <artifactId>json-simple</artifactId>
@@ -247,8 +247,7 @@
             <directory>src/main/resources</directory>
             <filtering>true</filtering>
           </resource>
-        </resources>  
-    
+        </resources>
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -319,8 +318,7 @@
                        </goals>
                    </execution>
                </executions>
-           </plugin>
-           
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
Hi Gill,

To avoid versioning conflicts with Spark, I aligned the versions of Stocator with the ones with Spark. Powermock isn't used by Spark, but the updated version of Mockito isn't compatible with Powermock 1.6.1, therefore we need to bump that one as well:
https://github.com/mockito/mockito/issues/190

Spark's pom: https://github.com/apache/spark/blob/master/pom.xml

Cheers, Fokko

Align the versions of the dependencies with the one from Spark



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

