### PR TITLE
Prepend the attempt to keep the valid extension

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/common/StocatorPath.java
+++ b/src/main/java/com/ibm/stocator/fs/common/StocatorPath.java
@@ -18,8 +18,6 @@
 package com.ibm.stocator.fs.common;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -29,7 +27,6 @@ import org.slf4j.LoggerFactory;
 import static com.ibm.stocator.fs.common.Constants.HADOOP_ATTEMPT;
 import static com.ibm.stocator.fs.common.Constants.HADOOP_TEMPORARY;
 import static com.ibm.stocator.fs.common.Constants.DEFAULT_FOUTPUTCOMMITTER_V1;
-import static com.ibm.stocator.fs.common.Constants.TRASH_FOLDER;
 
 public class StocatorPath {
   /*
@@ -38,7 +35,6 @@ public class StocatorPath {
   private static final Logger LOG = LoggerFactory.getLogger(StocatorPath.class);
 
   private String tempFileOriginator;
-  private String tempIdentifier;
   private String[] tempIdentifiers;
   private String hostNameScheme;
 
@@ -53,24 +49,12 @@ public class StocatorPath {
     tempFileOriginator = fileOriginator;
     hostNameScheme = hostName;
     if (tempFileOriginator.equals(DEFAULT_FOUTPUTCOMMITTER_V1)) {
-      tempIdentifier = HADOOP_TEMPORARY;
       tempIdentifiers = conf.getStrings("fs.stocator.temp.identifier",
           "_temporary/st_ID/_temporary/attempt_ID/");
     } else if (conf != null) {
       tempIdentifiers = conf.getStrings("fs.stocator.temp.identifier",
           "_temporary/st_ID/_temporary/attempt_ID/");
     }
-  }
-
-  public boolean isFileOutputComitter() {
-    return tempFileOriginator.equals(DEFAULT_FOUTPUTCOMMITTER_V1);
-  }
-
-  public boolean isTrashDestination(Path path) {
-    if (path.toString().contains(TRASH_FOLDER)) {
-      return true;
-    }
-    return false;
   }
 
   public boolean isTemporaryPathContain(Path path) {
@@ -127,43 +111,17 @@ public class StocatorPath {
    */
   public String getObjectNameRoot(Path fullPath, boolean addTaskId,
       String dataRoot, boolean addRoot) throws IOException {
-    String res = "";
+    String res;
     if (tempFileOriginator.equals(DEFAULT_FOUTPUTCOMMITTER_V1)) {
-      res =  parseHadoopFOutputCommitterV1(fullPath,
-          addTaskId, hostNameScheme);
+      res = parseHadoopFOutputCommitterV1(fullPath, addTaskId, hostNameScheme);
     } else {
-      res = extractNameFromTempPath(fullPath, addTaskId, hostNameScheme, false);
+      res = extractNameFromTempPath(fullPath, addTaskId, hostNameScheme);
     }
     if (!res.equals("")) {
       if (addRoot) {
         return dataRoot + "/" + res;
       }
       return res;
-    }
-    return fullPath.toString();
-  }
-
-  public String getGlobalPrefixName(Path fullPath,
-      String dataRoot, boolean addRoot) throws IOException {
-    String res = "";
-    res = extractNameFromTempPath(fullPath, false, hostNameScheme, true);
-    if (dataRoot.endsWith("/")) {
-      dataRoot = dataRoot.substring(0,  dataRoot.length() - 1);
-    }
-    if (!res.equals("")) {
-      if (addRoot) {
-        return dataRoot + "/" + res;
-      }
-      return res;
-    }
-    return fullPath.toString();
-  }
-
-  public String getActualPath(Path fullPath, boolean addTaskIdCompositeName,
-      String dataRoot) throws IOException {
-    if (isTemporaryPathContain(fullPath)) {
-      return hostNameScheme + getObjectNameRoot(fullPath, addTaskIdCompositeName,
-          dataRoot, false);
     }
     return fullPath.toString();
   }
@@ -172,11 +130,9 @@ public class StocatorPath {
    * @param p path
    * @param addTaskID add task id to the extracted name
    * @param hostName hostname used to register Stocator
-   * @param onlyPrefix return only prefix of the temp names
    * @return
    */
-  private String extractNameFromTempPath(Path p, boolean addTaskID, String hostName,
-      boolean onlyPrefix) {
+  private String extractNameFromTempPath(Path p, boolean addTaskID, String hostName) {
     LOG.trace("Extract name from {}", p.toString());
     String path = p.toString();
     // if path starts with host name - no need it, remove.
@@ -184,9 +140,9 @@ public class StocatorPath {
       path = path.substring(hostName.length());
     }
     // loop over all temporary identifiers and see if match
-    boolean match = true;
+    boolean match;
     String midName = "";
-    String namePrefix = "";
+    String namePrefix;
     for (String tempPath : tempIdentifiers) {
       LOG.trace("Temp identifier {}",tempPath);
       String taskAttempt = null;
@@ -196,20 +152,12 @@ public class StocatorPath {
       // if the 1st one match - most likely we hit the right one.
       // otherwise - proceed to the next temporary structure
       if (startIndex < 0) {
-        match = false;
         continue;
       }
       // get all the path components that are prefixed the temporary identifier
       namePrefix = path.substring(0, startIndex - 1);
       if (namePrefix.endsWith("_")) {
-        match = false;
         break;
-      }
-      if (onlyPrefix) {
-        if (namePrefix.startsWith("/")) {
-          return namePrefix.substring(1);
-        }
-        return namePrefix;
       }
       // we need to match temporary structure and take the rest
       String namePosix = path.substring(startIndex);
@@ -226,7 +174,7 @@ public class StocatorPath {
         } else if (tempPathComponents[i].equals("_ADD_")) {
           midName = midName + "/" + posixSplit[i];
         } else if (!tempPathComponents[i].contains("ID")
-            && !tempPathComponents[i].equals(posixSplit[i])) {
+                   && !tempPathComponents[i].equals(posixSplit[i])) {
           match = false;
           break;
         } else if (tempPathComponents[i].contains("ID")) { // not only contains, but also starts
@@ -239,7 +187,7 @@ public class StocatorPath {
             match = false;
             break;
           }
-          if (addTaskID && suffixID != null && suffixID.equals("ID")) {
+          if (addTaskID && suffixID.equals("ID")) {
             taskAttempt = Utils.extractTaskID(posixSplit[i], prefixID);
           }
         }
@@ -256,10 +204,15 @@ public class StocatorPath {
           }
         }
         if (posixSplit.length > tempPathComponents.length) {
+          String objName = posixSplit[posixSplit.length - 1];
           if (taskAttempt != null) {
-            return namePrefix + "/" + posixSplit[posixSplit.length - 1] + "-" + taskAttempt;
+            String extension = extractExtension(objName);
+            return namePrefix + "/"
+                   + objName.replace("." + extension, "")
+                   + "-" + taskAttempt
+                   + "." + objName;
           }
-          return namePrefix + "/" + posixSplit[posixSplit.length - 1];
+          return namePrefix + "/" + objName;
         }
         return namePrefix;
       }
@@ -274,7 +227,7 @@ public class StocatorPath {
    * aa/bb/cc/201610052038_0001_m_000007_15-one3.txt
    * otherwise object name will be aa/bb/cc/one3.txt
    *
-   * @param path path to extract from
+   * @param fullPath path to extract from
    * @param addTaskIdCompositeName if true will add task-id to the object name
    * @param hostNameScheme the host name
    * @return new object name
@@ -282,13 +235,12 @@ public class StocatorPath {
    */
   private String parseHadoopFOutputCommitterV1(Path fullPath,
       boolean addTaskIdCompositeName, String hostNameScheme) throws IOException {
-    String boundary = HADOOP_TEMPORARY;
     String path = fullPath.toString();
     String noPrefix = path;
     if (path.startsWith(hostNameScheme)) {
       noPrefix = path.substring(hostNameScheme.length());
     }
-    int npIdx = noPrefix.indexOf(boundary);
+    int npIdx = noPrefix.indexOf(HADOOP_TEMPORARY);
     String objectName = "";
     if (npIdx >= 0) {
       if (npIdx == 0 || npIdx == 1 && noPrefix.startsWith("/")) {
@@ -297,7 +249,7 @@ public class StocatorPath {
         //schema://tone1.lvm_temporary/0/_temporary/attempt_201610038_0001_m_000007_15/part-0007
         throw new IOException("Object name is missing");
       } else {
-        //path matches pattern in javadoc
+        // Will give: schema://tone1.lvm/aa/bb/cc/one3.txt/
         objectName = noPrefix.substring(0, npIdx - 1);
         if (addTaskIdCompositeName) {
           String objName = null;
@@ -315,7 +267,11 @@ public class StocatorPath {
             objName = fullPath.getName();
           }
           if (taskAttempt != null && !objName.startsWith(HADOOP_ATTEMPT)) {
-            objName = objName + "-" + taskAttempt;
+            // We want to prepend the attempt before the extension
+            String extension = extractExtension(objName);
+            objName = objName.replace("." + extension, "")
+                      + "-" + taskAttempt
+                      + "." + extension;
           }
           objectName = objectName + "/" + objName;
         }
@@ -325,38 +281,18 @@ public class StocatorPath {
     return noPrefix;
   }
 
-  public List<Tuple<String, String>> getAllPartitions(String path) {
-    List<Tuple<String, String>> res = new ArrayList<>();
-    if (path.contains("=")) {
-      String[] components = path.split("/");
-      for (String component : components) {
-        int pos = component.indexOf("=");
-        if (pos > 0) {
-          String key = component.substring(0, pos);
-          String value = component.substring(pos + 1);
-          res.add(new Tuple<String, String>(key, value));
-        }
-      }
+  /**
+   * A filename, for example, one3-attempt-01.txt.gz will return txt.gz
+   *
+   * @param filename The path of filename to extract the extension from
+   * @return The extension of the filename
+   */
+  private String extractExtension(String filename) {
+    int startExtension = filename.indexOf('.');
+    if (startExtension > 0) {
+      return filename.substring(startExtension + 1);
     }
-    return res;
-  }
-
-  public boolean isPartitionTarget(Path path) {
-    String name = path.getName();
-    LOG.debug("Is partition target for {} from {}", name, path.toString());
-    if (name != null && name.contains("=")) {
-      return true;
-    }
-    return false;
-  }
-
-  public boolean isPartitionExists(Path path) {
-    String name = path.toString();
-    LOG.debug("Is partition target for {} from {}", name, path.toString());
-    if (name != null && name.contains("=")) {
-      return true;
-    }
-    return false;
+    return "";
   }
 
   /**

--- a/src/main/java/com/ibm/stocator/fs/common/StocatorPath.java
+++ b/src/main/java/com/ibm/stocator/fs/common/StocatorPath.java
@@ -241,7 +241,7 @@ public class StocatorPath {
       noPrefix = path.substring(hostNameScheme.length());
     }
     int npIdx = noPrefix.indexOf(HADOOP_TEMPORARY);
-    String objectName = "";
+    String objectName;
     if (npIdx >= 0) {
       if (npIdx == 0 || npIdx == 1 && noPrefix.startsWith("/")) {
         //no object name present
@@ -269,9 +269,10 @@ public class StocatorPath {
           if (taskAttempt != null && !objName.startsWith(HADOOP_ATTEMPT)) {
             // We want to prepend the attempt before the extension
             String extension = extractExtension(objName);
-            objName = objName.replace("." + extension, "")
-                      + "-" + taskAttempt
-                      + "." + extension;
+            objName = objName.replace("." + extension, "") + "-" + taskAttempt;
+            if (!extension.equals("")) {
+              objName += "." + extension;
+            }
           }
           objectName = objectName + "/" + objName;
         }

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -761,7 +761,7 @@ public class SwiftAPIClient implements IStoreClient {
    * Accepts any object name.
    * If object name of the form
    * a/b/c/gil.data/part-r-00000-48ae3461-203f-4dd3-b141-a45426e2d26c
-   *    .csv-attempt_20160317132a_wrong_0000_m_000000_1
+   *    -attempt_20160317132a_wrong_0000_m_000000_1.csv
    * Then a/b/c/gil.data is returned.
    * Code testing that attempt_20160317132a_wrong_0000_m_000000_1 is valid
    * task id identifier
@@ -771,8 +771,9 @@ public class SwiftAPIClient implements IStoreClient {
    */
   private String extractUnifiedObjectName(String objectName) {
     Path p = new Path(objectName);
-    if (objectName.indexOf("-" + HADOOP_ATTEMPT) > 0) {
-      String attempt = objectName.substring(objectName.lastIndexOf("-") + 1);
+    int attemptIndex = objectName.indexOf(HADOOP_ATTEMPT);
+    if (attemptIndex >= 0) {
+      String attempt = objectName.substring(attemptIndex, objectName.lastIndexOf('.'));
       try {
         TaskAttemptID.forName(attempt);
         return p.getParent().toString();
@@ -789,7 +790,7 @@ public class SwiftAPIClient implements IStoreClient {
    * Accepts any object name.
    * If object name is of the form
    * a/b/c/m.data/part-r-00000-48ae3461-203f-4dd3-b141-a45426e2d26c
-   *    .csv-attempt_20160317132a_wrong_0000_m_000000_1
+   *    -attempt_20160317132a_wrong_0000_m_000000_1.csv
    * Then a/b/c/m.data/part-r-00000-48ae3461-203f-4dd3-b141-a45426e2d26c.csv is returned.
    * Perform test that attempt_20160317132a_wrong_0000_m_000000_1 is valid
    * task id identifier
@@ -798,12 +799,12 @@ public class SwiftAPIClient implements IStoreClient {
    * @return unified object name
    */
   private String nameWithoutTaskID(String objectName) {
-    int index = objectName.indexOf("-" + HADOOP_ATTEMPT);
+    int index = objectName.indexOf(HADOOP_ATTEMPT);
     if (index > 0) {
-      String attempt = objectName.substring(objectName.lastIndexOf("-") + 1);
+      String attempt = objectName.substring(index, objectName.lastIndexOf('.'));
       try {
         TaskAttemptID.forName(attempt);
-        return objectName.substring(0, index);
+        return objectName.replace("-" + attempt , "");
       } catch (IllegalArgumentException e) {
         return objectName;
       }

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -772,8 +772,9 @@ public class SwiftAPIClient implements IStoreClient {
   private String extractUnifiedObjectName(String objectName) {
     Path p = new Path(objectName);
     int attemptIndex = objectName.indexOf(HADOOP_ATTEMPT);
-    if (attemptIndex >= 0) {
-      String attempt = objectName.substring(attemptIndex, objectName.lastIndexOf('.'));
+    int dotIndex = objectName.lastIndexOf('.');
+    if (attemptIndex >= 0 && dotIndex > attemptIndex) {
+      String attempt = objectName.substring(attemptIndex, dotIndex);
       try {
         TaskAttemptID.forName(attempt);
         return p.getParent().toString();

--- a/src/main/java/com/ibm/stocator/fs/swift/http/SwiftConnectionManager.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/http/SwiftConnectionManager.java
@@ -107,7 +107,6 @@ public class SwiftConnectionManager {
     HttpRequestRetryHandler myRetryHandler = new HttpRequestRetryHandler() {
 
       public boolean retryRequest(IOException exception, int executionCount, HttpContext context) {
-        System.out.println(executionCount);
         if (executionCount >= connectionConfiguration.getExecutionCount()) {
           // Do not retry if over max retry count
           LOG.debug("Execution count {} is bigger then threashold. Stop", executionCount);

--- a/src/test/java/com/ibm/stocator/fs/commom/unittests/StocatorPathTest.java
+++ b/src/test/java/com/ibm/stocator/fs/commom/unittests/StocatorPathTest.java
@@ -82,45 +82,45 @@ public class StocatorPathTest {
     String hostname = "swift2d://a.service/";
 
     String input = "swift2d://a.service/aa/bb/cc/one3.txt/_temporary/0/_temporary/"
-        + "attempt_201610052038_0001_m_000007_15/part-00007";
+                   + "attempt_201610052038_0001_m_000007_15/part-00007";
     String expectedResult = "aa/bb/cc/one3.txt/part-00007";
     String result = Whitebox.invokeMethod(mStocatorPath, "extractNameFromTempPath",
-        new Path(input), false, hostname, false);
+                                          new Path(input), false, hostname);
     Assert.assertEquals("extractObectNameFromTempPath() shows incorrect name",
-            expectedResult, result);
+                        expectedResult, result);
 
     input = "swift2d://a.service/one3.txt/_temporary/0/_temporary/"
-        + "attempt_201610052038_0001_m_000007_15/a/part-00007";
+            + "attempt_201610052038_0001_m_000007_15/a/part-00007";
     expectedResult = "one3.txt/a/part-00007";
     result = Whitebox.invokeMethod(mStocatorPath, "extractNameFromTempPath",
-        new Path(input), false, hostname, false);
+                                   new Path(input), false, hostname);
     Assert.assertEquals("extractObectNameFromTempPath() shows incorrect name",
-            expectedResult, result);
+                        expectedResult, result);
 
     input = "swift2d://a.service/one3.txt/_temporary/0/_temporary/"
-        + "attempt_201610052038_0001_m_000007_15/";
+            + "attempt_201610052038_0001_m_000007_15/";
     expectedResult = "one3.txt";
     result = Whitebox.invokeMethod(mStocatorPath, "extractNameFromTempPath",
-        new Path(input), false, hostname, false);
+                                   new Path(input), false, hostname);
     Assert.assertEquals("extractObectNameFromTempPath() shows incorrect name",
-            expectedResult, result);
+                        expectedResult, result);
 
     input = "swift2d://a.service/one3.txt/_temporary/0/_temporary/"
-        + "attempt_201610052038_0001_m_000007_15";
+            + "attempt_201610052038_0001_m_000007_15";
     expectedResult = "one3.txt";
     result = Whitebox.invokeMethod(mStocatorPath, "extractNameFromTempPath",
-        new Path(input), false, hostname, false);
+                                   new Path(input), false, hostname);
     Assert.assertEquals("extractObectNameFromTempPath() shows incorrect name",
-            expectedResult, result);
+                        expectedResult, result);
 
     input = "swift2d://a.service/one3.txt/_temporary/0/_temporary/"
-        + "attampt_201610052038_0001_m_000007_15";
+            + "attampt_201610052038_0001_m_000007_15";
     expectedResult = "one3.txt/_temporary/0/_temporary/"
-        + "attampt_201610052038_0001_m_000007_15";
+                     + "attampt_201610052038_0001_m_000007_15";
     result = Whitebox.invokeMethod(mStocatorPath, "extractNameFromTempPath",
-        new Path(input), false, hostname, false);
+                                   new Path(input), false, hostname);
     Assert.assertEquals("extractObectNameFromTempPath() shows incorrect name",
-            expectedResult, result);
+                        expectedResult, result);
 
   }
 
@@ -145,8 +145,9 @@ public class StocatorPathTest {
         + "_temporary/0/_temporary/attempt_20171115113432_0017_m_000076_0/"
         + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8.snappy.parquet";
     String expectedResult = "a/aa/abc.parquet/"
-        + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8.snappy.parquet"
-        + "-attempt_20171115113432_0017_m_000076_0";
+        + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8"
+        + "-attempt_20171115113432_0017_m_000076_0"
+        + ".snappy.parquet";
 
     String result = stocPath.getObjectNameRoot(new Path(input), true, "a", true);
     Assert.assertEquals("getObjectNameRoot() shows incorrect name",
@@ -158,8 +159,9 @@ public class StocatorPathTest {
         + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8.snappy.parquet";
     expectedResult = "a/aa/abc.parquet/"
         + "YEAR=2003/"
-        + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8.snappy.parquet"
-        + "-attempt_20171115113432_0017_m_000076_0";
+        + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8"
+        + "-attempt_20171115113432_0017_m_000076_0"
+        + ".snappy.parquet";
 
     result = stocPath.getObjectNameRoot(new Path(input), true, "a", true);
     Assert.assertEquals("getObjectNameRoot() shows incorrect name",
@@ -171,8 +173,9 @@ public class StocatorPathTest {
         + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8.snappy.parquet";
     expectedResult = "a/aa/abc.parquet/"
         + "D_DATE=2003-01-10 00%3A00%3A00/"
-        + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8.snappy.parquet"
-        + "-attempt_20171115113432_0017_m_000076_0";
+        + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8"
+        + "-attempt_20171115113432_0017_m_000076_0"
+        + ".snappy.parquet";
 
     result = stocPath.getObjectNameRoot(new Path(input), true, "a", true);
     Assert.assertEquals("getObjectNameRoot() shows incorrect name",

--- a/src/test/java/com/ibm/stocator/fs/commom/unittests/StocatorPathTest.java
+++ b/src/test/java/com/ibm/stocator/fs/commom/unittests/StocatorPathTest.java
@@ -122,6 +122,14 @@ public class StocatorPathTest {
     Assert.assertEquals("extractObectNameFromTempPath() shows incorrect name",
                         expectedResult, result);
 
+    input = "swift2d://a.service/one3/_temporary/0/_temporary/"
+            + "attampt_201610052038_0001_m_000007_15";
+    expectedResult = "one3/_temporary/0/_temporary/"
+                     + "attampt_201610052038_0001_m_000007_15";
+    result = Whitebox.invokeMethod(mStocatorPath, "extractNameFromTempPath",
+                                   new Path(input), false, hostname);
+    Assert.assertEquals("extractObectNameFromTempPath() shows incorrect name",
+                        expectedResult, result);
   }
 
   @Test
@@ -180,6 +188,19 @@ public class StocatorPathTest {
     result = stocPath.getObjectNameRoot(new Path(input), true, "a", true);
     Assert.assertEquals("getObjectNameRoot() shows incorrect name",
             expectedResult, result);
+
+    input = "swift2d://a.service/aa/abc.parquet/"
+        + "_temporary/0/_temporary/attempt_20171115113432_0017_m_000076_0/"
+        + "D_DATE=2003-01-10 00%3A00%3A00/"
+        + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8";
+    expectedResult = "a/aa/abc.parquet/"
+        + "D_DATE=2003-01-10 00%3A00%3A00/"
+        + "part-00076-335c9928-ccbb-4830-b7e3-0348a7d7d8f8"
+        + "-attempt_20171115113432_0017_m_000076_0";
+
+    result = stocPath.getObjectNameRoot(new Path(input), true, "a", true);
+    Assert.assertEquals("getObjectNameRoot() shows incorrect name",
+                        expectedResult, result);
 
   }
 

--- a/src/test/java/com/ibm/stocator/fs/swift2d/systemtests/ObjectStoreFileSystemTest.java
+++ b/src/test/java/com/ibm/stocator/fs/swift2d/systemtests/ObjectStoreFileSystemTest.java
@@ -42,9 +42,9 @@ public class ObjectStoreFileSystemTest extends SwiftBaseTest {
   private ObjectStoreFileSystem mMockObjectStoreFileSystem;
   private StocatorPath mMockStocatorPath;
   private String hostName = "swift2d://out1003.lvm";
-  protected byte[] data = SwiftTestUtils.generateDataset(getBlockSize() * 2, 0, 255);
-  String fileName = null;
-  int iterNum = 3;
+  private byte[] data = SwiftTestUtils.generateDataset(getBlockSize() * 2, 0, 255);
+  private String fileName = null;
+  private int iterNum = 3;
 
   @Before
   public final void before() throws Exception {
@@ -125,7 +125,7 @@ public class ObjectStoreFileSystemTest extends SwiftBaseTest {
   }
 
   @Test
-  public void getSchemeTest() throws Exception {
+  public void getSchemeTest() {
     Assume.assumeNotNull(getFs());
     Assert.assertEquals(Constants.SWIFT2D, getFs().getScheme());
   }

--- a/src/test/java/com/ibm/stocator/fs/swift2d/systemtests/TestSwiftOperations.java
+++ b/src/test/java/com/ibm/stocator/fs/swift2d/systemtests/TestSwiftOperations.java
@@ -122,9 +122,6 @@ public class TestSwiftOperations extends SwiftBaseTest {
     ObjectStoreGlobber globber = new ObjectStoreGlobber(getFs(), wildcard,
             new ObjectStoreGlobFilter(wildcard.toString()));
     FileStatus[] results = globber.glob();
-    for (FileStatus res: results) {
-      System.out.println(res.getPath());
-    }
     assertEquals(3, results.length);
 
     wildcard = new Path(getBaseURI() + "/Dir/*"); // Files in "Dir" directory

--- a/src/test/java/com/ibm/stocator/fs/swift2d/unittests/SwiftAPIClientTest.java
+++ b/src/test/java/com/ibm/stocator/fs/swift2d/unittests/SwiftAPIClientTest.java
@@ -86,15 +86,17 @@ public class SwiftAPIClientTest {
             objectUnified, result);
 
     input = objectUnified + "/"
-        + "part-r-00000-48ae3461-203f-4dd3-b141-a45426e2d26c.csv-"
-        + "attempt_201603171328_0000_m_000000_1";
+        + "part-r-00000-48ae3461-203f-4dd3-b141-a45426e2d26c"
+        + "-attempt_201603171328_0000_m_000000_1"
+        + ".csv";
     result = Whitebox.invokeMethod(mSwiftAPIClient, "extractUnifiedObjectName", input);
     Assert.assertEquals("extractUnifiedObjectName() shows incorrect name with attempt",
             objectUnified, result);
 
     input = "a/b/c/gil.data/"
-        + "part-r-00000-48ae3461-203f-4dd3-b141-a45426e2d26c.csv-"
-        + "attempt_20160317132a_wrong_0000_m_000000_1";
+        + "part-r-00000-48ae3461-203f-4dd3-b141-a45426e2d26c"
+        + "-attempt_20160317132a_wrong_0000_m_000000_1"
+        + ".csv";
     result = Whitebox.invokeMethod(mSwiftAPIClient, "extractUnifiedObjectName", input);
     Assert.assertEquals("extractUnifiedObjectName() shows incorrect name with wrong taskAttemptID",
             input, result);
@@ -103,17 +105,14 @@ public class SwiftAPIClientTest {
   @Test
   public void nameWithoutTaskIDTest() throws Exception {
     String objectName = "a/b/c/gil.data/"
-            + "part-r-00000-48ae3461-203f-4dd3-b141-a45426e2d26c.csv";
+            + "part-r-00000-48ae3461-203f-4dd3-b141-a45426e2d26c";
 
-    String input = objectName;
-    input = objectName
-            + "-attempt_201603171328_0000_m_000000_1";
+    String input = objectName + "-attempt_201603171328_0000_m_000000_1.csv";
     String result = Whitebox.invokeMethod(mSwiftAPIClient, "nameWithoutTaskID", input);
     Assert.assertEquals("nameWithoutTaskID() shows incorrect name",
-            objectName, result);
+            objectName + ".csv", result);
 
-    input = objectName
-            + "attempt_20160317132a_wrong_0000_m_000000_1";
+    input = objectName + "-attempt_20160317132a_wrong_0000_m_000000_1.csv";
     result = Whitebox.invokeMethod(mSwiftAPIClient, "nameWithoutTaskID", input);
     Assert.assertEquals("nameWithoutTaskID() shows incorrect name with wrong taskAttemptID",
             input, result);


### PR DESCRIPTION
Hi Gil,

I've patched some issues with writing files other than Parquet. We've discussed this earlier, but when writing json/csv, the compression is ignored upon reading. This is because the `attempt_` is appended and therefore the extension isn't picked up anymore.

As from http://comphadoop.weebly.com/

_If the input files are compressed, they will be decompressed automatically as they are read by MapReduce, using the filename extension to determine which codec to use. For example, a file ending in .gz can be identified as gzip-compressed file and thus read with GzipCodec._

I can imagine that this is a big change. If there are any further questions, please let me know. But I think it is important to get this in, to be compatible with csv/json/text/ etc.

I also did a test with the current master of stocator and my branch:

```
scala> val data = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
data: String = Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.

scala> val arr = data.split(" ")
arr: Array[String] = Array(Lorem, Ipsum, is, simply, dummy, text, of, the, printing, and, typesetting, industry., Lorem, Ipsum, has, been, the, industrys, standard, dummy, text, ever, since, the, 1500s,, when, an, unknown, printer, took, a, galley, of, type, and, scrambled, it, to, make, a, type, specimen, book., It, has, survived, not, only, five, centuries,, but, also, the, leap, into, electronic, typesetting,, remaining, essentially, unchanged., It, was, popularised, in, the, 1960s, with, the, release, of, Letraset, sheets, containing, Lorem, Ipsum, passages,, and, more, recently, with, desktop, publishing, software, like, Aldus, PageMaker, including, versions, of, Lorem, Ipsum.)

scala> val distData = sc.parallelize(arr)
distData: org.apache.spark.rdd.RDD[String] = ParallelCollectionRDD[1] at parallelize at <console>:28

scala> val df = distData.toDF("word")
df: org.apache.spark.sql.DataFrame = [word: string]

scala> df.write.option("compression", "bzip2").json("swift2d://druid.mobpro/test-prepend/")

scala> spark.read.json("swift2d://druid.mobpro/test-prepend/").show()
+------------+                                                                  
|        word|
+------------+
|    survived|
|         not|
|        only|
|        five|
|  centuries,|
|         but|
|        also|
|         the|
|        leap|
|        into|
|  electronic|
|typesetting,|
|   remaining|
| essentially|
|  unchanged.|
|          It|
|         was|
| popularised|
|          in|
|         the|
+------------+
only showing top 20 rows
```

And stocator's master:
```
scala> val data = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
data: String = Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industrys standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.

scala> val arr = data.split(" ")
arr: Array[String] = Array(Lorem, Ipsum, is, simply, dummy, text, of, the, printing, and, typesetting, industry., Lorem, Ipsum, has, been, the, industrys, standard, dummy, text, ever, since, the, 1500s,, when, an, unknown, printer, took, a, galley, of, type, and, scrambled, it, to, make, a, type, specimen, book., It, has, survived, not, only, five, centuries,, but, also, the, leap, into, electronic, typesetting,, remaining, essentially, unchanged., It, was, popularised, in, the, 1960s, with, the, release, of, Letraset, sheets, containing, Lorem, Ipsum, passages,, and, more, recently, with, desktop, publishing, software, like, Aldus, PageMaker, including, versions, of, Lorem, Ipsum.)

scala> val distData = sc.parallelize(arr)
distData: org.apache.spark.rdd.RDD[String] = ParallelCollectionRDD[0] at parallelize at <console>:28

scala> val df = distData.toDF("word")
df: org.apache.spark.sql.DataFrame = [word: string]

scala> df.write.option("compression", "bzip2").json("swift2d://druid.mobpro/test-append/")

scala> spark.read.json("swift2d://druid.mobpro/test-append/").show()
+--------------------+
|     _corrupt_record|
+--------------------+
|BZh91AY&SY�{ƸK]...|
+--------------------+
```

The data on the SWIFT store using Swift explorer:

![image](https://user-images.githubusercontent.com/1134248/34688974-38a4ebcc-f4b4-11e7-9f37-7da8c97d1c4a.png)


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.


  